### PR TITLE
Added DOMIterator for depth-first and breadth-first tree traversal

### DIFF
--- a/lab-3/RedoneComposer/BreadthFirstIterator.cs
+++ b/lab-3/RedoneComposer/BreadthFirstIterator.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RedoneComposer
+{
+    public class BreadthFirstIterator : IDOMIterator
+    {
+        private readonly LightNode _root;
+        private Queue<LightNode> _queue;
+        private Dictionary<LightNode, int> _levels;
+        private int _currentLevel;
+
+        public int CurrentLevel => _currentLevel;
+
+        public BreadthFirstIterator(LightNode root)
+        {
+            _root = root;
+            Reset();
+        }
+
+        public bool HasNext()
+        {
+            return _queue.Count > 0;
+        }
+
+        public LightNode Next()
+        {
+            if (!HasNext())
+                throw new InvalidOperationException("No more elements");
+
+            var node = _queue.Dequeue();
+            _currentLevel = _levels[node];
+            return node;
+        }
+
+        public void Reset()
+        {
+            _queue = new Queue<LightNode>();
+            _levels = new Dictionary<LightNode, int>();
+            _currentLevel = 0;
+
+            var tempQueue = new Queue<(LightNode node, int level)>();
+            tempQueue.Enqueue((_root, 0));
+
+            while (tempQueue.Count > 0)
+            {
+                var (currentNode, currentLevel) = tempQueue.Dequeue();
+
+                _queue.Enqueue(currentNode);
+                _levels[currentNode] = currentLevel;
+
+                if (currentNode is LightElementNode elementNode)
+                {
+                    foreach (var child in elementNode.ChildNodes)
+                    {
+                        if (child is LightTextNode)
+                        {
+                            tempQueue.Enqueue((child, currentLevel + 1));
+                        }
+                    }
+
+                   
+                    foreach (var child in elementNode.ChildNodes)
+                    {
+                        if (child is LightElementNode)
+                        {
+                            tempQueue.Enqueue((child, currentLevel + 1));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lab-3/RedoneComposer/DepthFirstIterator.cs
+++ b/lab-3/RedoneComposer/DepthFirstIterator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RedoneComposer
+{
+    public class DepthFirstIterator : IDOMIterator
+    {
+        private readonly LightNode _root;
+        private Stack<LightNode> _stack;
+        private Dictionary<LightNode, int> _levels;
+        private int _currentLevel;
+
+        public int CurrentLevel => _currentLevel;
+
+        public DepthFirstIterator(LightNode root)
+        {
+            _root = root;
+            Reset();
+        }
+
+        public bool HasNext()
+        {
+            return _stack.Count > 0;
+        }
+
+        public LightNode Next()
+        {
+            if (!HasNext())
+                throw new InvalidOperationException("No more elements");
+
+            var current = _stack.Pop();
+            _currentLevel = _levels[current];
+
+            if (current is LightElementNode elementNode)
+            {
+                for (int i = elementNode.ChildNodes.Count - 1; i >= 0; i--)
+                {
+                    var child = elementNode.ChildNodes[i];
+                    _stack.Push(child);
+                    _levels[child] = _currentLevel + 1;
+                }
+            }
+
+            return current;
+        }
+
+        public void Reset()
+        {
+            _stack = new Stack<LightNode>();
+            _levels = new Dictionary<LightNode, int>();
+            _currentLevel = 0;
+            _stack.Push(_root);
+            _levels[_root] = 0;
+        }
+    }
+}

--- a/lab-3/RedoneComposer/IDOMIterator.cs
+++ b/lab-3/RedoneComposer/IDOMIterator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedoneComposer
+{
+    public interface IDOMIterator
+    {
+        bool HasNext();
+        LightNode Next();
+        void Reset();
+        int CurrentLevel { get; } 
+    }
+
+}

--- a/lab-3/RedoneComposer/LightElementNode.cs
+++ b/lab-3/RedoneComposer/LightElementNode.cs
@@ -78,6 +78,15 @@ namespace RedoneComposer
         }
 
 
+        public IDOMIterator GetDepthFirstIterator()
+        {
+            return new DepthFirstIterator(this);
+        }
+
+        public IDOMIterator GetBreadthFirstIterator()
+        {
+            return new BreadthFirstIterator(this);
+        }
 
         public override string OuterHTML()
         {

--- a/lab-3/RedoneComposer/Program.cs
+++ b/lab-3/RedoneComposer/Program.cs
@@ -1,6 +1,5 @@
 ﻿using RedoneComposer;
 using System;
-using System.Collections.Generic;
 
 public class Program
 {
@@ -135,5 +134,58 @@ public class Program
 
         Console.WriteLine("\nКінцевий HTML:");
         Console.WriteLine(rootDiv2.OuterHTML());
+
+        Console.WriteLine("\nДемонстрація роботи ітераторів:");
+        Console.WriteLine("--------------------------------");
+
+        Console.WriteLine("\nОбхід DOM в глибину (Depth-First):");
+        var depthIterator = rootDiv.GetDepthFirstIterator();
+
+        while (depthIterator.HasNext())
+        {
+            var node = depthIterator.Next();
+            var level = depthIterator.CurrentLevel;
+
+            if (node is LightElementNode elementNode)
+            {
+                Console.WriteLine($"[Рівень {level}] Елемент: <{elementNode.TagName}>");
+            }
+            else if (node is LightTextNode textNode)
+            {
+                string escapedText = textNode.TextContent.Replace("'", "\\'");
+                Console.WriteLine($"[Рівень {level}] Текст: \"{escapedText}\"");
+            }
+        }
+
+        Console.WriteLine("\nОбхід DOM в ширину (Breadth-First) з правильними рівнями:");
+        var breadthIterator = rootDiv.GetBreadthFirstIterator();
+        string currentSection = "";
+
+        while (breadthIterator.HasNext())
+        {
+            var node = breadthIterator.Next();
+            var level = breadthIterator.CurrentLevel;  
+
+            if (node is LightElementNode elementNode)
+            {
+                if (elementNode.TagName == "table" && currentSection != "table")
+                {
+                    Console.WriteLine("\n--- Таблиця ---");
+                    currentSection = "table";
+                }
+                else if (elementNode.TagName == "ul" && currentSection != "list")
+                {
+                    Console.WriteLine("\n--- Список ---");
+                    currentSection = "list";
+                }
+
+                Console.WriteLine($"[Рівень {level}] Елемент: <{elementNode.TagName}>");
+            }
+            else if (node is LightTextNode textNode)
+            {
+                string escapedText = textNode.TextContent.Replace("'", "\\'");
+                Console.WriteLine($"[Рівень {level}] Текст: \"{escapedText}\"");
+            }
+        }
     }
 }


### PR DESCRIPTION
Implemented a DOMIterator class that allows traversing the DOM tree in both depth-first and breadth-first order.
(This is also my 2nd added feature for the Modular test №1.)