### PR TITLE
Add Command pattern implementation with undo/redo functionality

### DIFF
--- a/lab-3/RedoneComposer/CommandPattern.cs
+++ b/lab-3/RedoneComposer/CommandPattern.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+s
+namespace RedoneComposer
+{
+    public interface ICommand
+    {
+        void Execute();
+        void Undo();
+        void Redo();
+    }
+
+    internal class AddChildCommand : ICommand
+    {
+        private readonly LightElementNode _parent;
+        private readonly LightNode _child;
+        private bool _isExecuted = false;
+
+        public AddChildCommand(LightElementNode parent, LightNode child)
+        {
+            _parent = parent;
+            _child = child;
+        }
+
+        public void Execute()
+        {
+            if (!_isExecuted)
+            {
+                _parent.AddChild(_child);
+                _isExecuted = true;
+            }
+        }
+
+        public void Undo()
+        {
+            if (_isExecuted)
+            {
+                _parent.RemoveChild(_child);
+                _isExecuted = false;
+            }
+        }
+
+        public void Redo()
+        {
+            if (!_isExecuted)
+            {
+                _parent.AddChild(_child);
+                _isExecuted = true;
+            }
+        }
+    }
+
+    internal class RemoveChildCommand : ICommand
+    {
+        private readonly LightElementNode _parent;
+        private readonly LightNode _child;
+        private bool _isExecuted = false;
+        private int _originalIndex = -1;
+
+        public RemoveChildCommand(LightElementNode parent, LightNode child)
+        {
+            _parent = parent;
+            _child = child;
+        }
+
+        public void Execute()
+        {
+            if (!_isExecuted)
+            {
+                _originalIndex = _parent.ChildNodes.IndexOf(_child);
+                if (_originalIndex >= 0)
+                {
+                    _parent.RemoveChild(_child);
+                    _isExecuted = true;
+                }
+            }
+        }
+
+        public void Undo()
+        {
+            if (_isExecuted && _originalIndex >= 0)
+            {
+                if (_originalIndex <= _parent.ChildNodes.Count)
+                {
+                    _parent.ChildNodes.Insert(_originalIndex, _child);
+                }
+                else
+                {
+                    _parent.AddChild(_child);
+                }
+                _isExecuted = false;
+            }
+        }
+
+        public void Redo()
+        {
+            if (!_isExecuted)
+            {
+                Execute(); // Повторно виконуємо видалення
+            }
+        }
+    }
+
+    public class CommandHistory
+    {
+        private readonly Stack<ICommand> _undoStack = new Stack<ICommand>();
+        private readonly Stack<ICommand> _redoStack = new Stack<ICommand>();
+
+        public void ExecuteCommand(ICommand command)
+        {
+            command.Execute();
+            _undoStack.Push(command);
+            _redoStack.Clear();
+        }
+
+        public void Undo()
+        {
+            if (_undoStack.Count > 0)
+            {
+                var command = _undoStack.Pop();
+                command.Undo();
+                _redoStack.Push(command);
+            }
+        }
+
+        public void Redo()
+        {
+            if (_redoStack.Count > 0)
+            {
+                var command = _redoStack.Pop();
+                command.Redo();
+                _undoStack.Push(command);
+            }
+        }
+    }
+}

--- a/lab-3/RedoneComposer/Program.cs
+++ b/lab-3/RedoneComposer/Program.cs
@@ -187,5 +187,48 @@ public class Program
                 Console.WriteLine($"[Рівень {level}] Текст: \"{escapedText}\"");
             }
         }
+
+
+        Console.WriteLine("\nДемонстрація шаблону Команда (Історія дій):");
+        Console.WriteLine("-----------------------------------------");
+
+        var commandHistory = new CommandHistory();
+        var demoDiv = new LightElementNode("div", "block", false);
+
+        Console.WriteLine("\nПочатковий HTML:");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+        var heading4 = new LightElementNode("h1", "block", false);
+        var addHeadingCommand = new AddChildCommand(demoDiv, heading4);
+        commandHistory.ExecuteCommand(addHeadingCommand);
+
+        Console.WriteLine("\nПісля додавання заголовка:");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+        var textNode4 = new LightTextNode("Демонстрація команди");
+        var addTextCommand = new AddChildCommand(heading4, textNode4);
+        commandHistory.ExecuteCommand(addTextCommand);
+
+        Console.WriteLine("\nПісля додавання тексту:");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+        commandHistory.Undo();
+        Console.WriteLine("\nПісля Undo (видалення тексту):");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+
+        commandHistory.Redo();
+        Console.WriteLine("\nПісля Redo (повторне додавання тексту):");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+        var removeHeadingCommand = new RemoveChildCommand(demoDiv, heading4);
+        commandHistory.ExecuteCommand(removeHeadingCommand);
+
+        Console.WriteLine("\nПісля видалення заголовка:");
+        Console.WriteLine(demoDiv.OuterHTML());
+
+        commandHistory.Undo();
+        Console.WriteLine("\nПісля Undo (повернення заголовка):");
+        Console.WriteLine(demoDiv.OuterHTML());
     }
 }


### PR DESCRIPTION
Added Command pattern implementation with support for undo and redo operations.
Each action (e.g. adding or removing a node) is encapsulated as a command object, allowing actions to be reversed or reapplied easily.
(This is also my 3rd added feature for the Modular test №1.)