### PR TITLE
Add HTML validation using Visitor pattern

### DIFF
--- a/lab-3/RedoneComposer/HtmlValidationVisitor.cs
+++ b/lab-3/RedoneComposer/HtmlValidationVisitor.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedoneComposer
+{
+    internal class HtmlValidationVisitor : INodeVisitor
+    {
+        private readonly Stack<LightElementNode> _elementStack = new Stack<LightElementNode>();
+        private readonly List<string> _errors = new List<string>();
+
+        public IReadOnlyList<string> Errors => _errors;
+
+        public void VisitElement(LightElementNode element)
+        {
+            ValidateElement(element);
+            _elementStack.Push(element);
+        }
+
+        public void VisitText(LightTextNode text)
+        {
+            // Текстові вузли не потребують валідації
+        }
+
+        public void VisitImage(LightImageNode image)
+        {
+            // Зображення не потребують валідації
+        }
+
+        private void ValidateElement(LightElementNode element)
+        {
+            if (_elementStack.Count > 0)
+            {
+                var parent = _elementStack.Peek();
+                ValidateParentChildRelation(parent, element);
+            }
+
+            ValidateElementSpecificRules(element);
+        }
+
+        private void ValidateParentChildRelation(LightElementNode parent, LightElementNode child)
+        {
+            switch (child.TagName.ToLower())
+            {
+                case "li":
+                    if (parent.TagName.ToLower() != "ul" && parent.TagName.ToLower() != "ol")
+                    {
+                        _errors.Add($"Помилка: <li> може бути тільки всередині <ul> або <ol> (знайдено всередині <{parent.TagName}>)");
+                    }
+                    break;
+
+                case "tr":
+                    if (parent.TagName.ToLower() != "table")
+                    {
+                        _errors.Add($"Помилка: <tr> може бути тільки всередині <table> (знайдено всередині <{parent.TagName}>)");
+                    }
+                    break;
+
+                case "th":
+                case "td":
+                    if (parent.TagName.ToLower() != "tr")
+                    {
+                        _errors.Add($"Помилка: <{child.TagName}> може бути тільки всередині <tr> (знайдено всередині <{parent.TagName}>)");
+                    }
+                    break;
+            }
+        }
+
+        private void ValidateElementSpecificRules(LightElementNode element)
+        {
+            switch (element.TagName.ToLower())
+            {
+                case "a":
+                    if (!element.ChildNodes.Exists(n => n is LightTextNode))
+                    {
+                        _errors.Add($"Попередження: <a> повинен містити текстовий вміст");
+                    }
+                    break;
+
+                case "ul":
+                case "ol":
+                    if (!element.ChildNodes.Exists(n => n is LightElementNode && ((LightElementNode)n).TagName.ToLower() == "li"))
+                    {
+                        _errors.Add($"Попередження: <{element.TagName}> повинен містити хоча б один <li>");
+                    }
+                    break;
+
+                case "table":
+                    bool hasHeader = element.ChildNodes.Exists(n =>
+                        n is LightElementNode &&
+                        ((LightElementNode)n).TagName.ToLower() == "tr" &&
+                        ((LightElementNode)n).ChildNodes.Exists(c =>
+                            c is LightElementNode &&
+                            ((LightElementNode)c).TagName.ToLower() == "th"));
+
+                    if (!hasHeader)
+                    {
+                        _errors.Add($"Попередження: <table> рекомендується мати заголовок (<th>)");
+                    }
+                    break;
+            }
+        }
+
+        public void AfterVisit()
+        {
+            _elementStack.Clear();
+        }
+    }
+}

--- a/lab-3/RedoneComposer/Program.cs
+++ b/lab-3/RedoneComposer/Program.cs
@@ -316,9 +316,61 @@ public class Program
         history.ExecuteCommand(createTableMacro);
 
         Console.WriteLine("\nРезультат після створення таблиці:");
-        Console.WriteLine(macroContainer.OuterHTML()); 
+        Console.WriteLine(macroContainer.OuterHTML());
 
- 
+
+
+
+
+
+
+        
+        Console.WriteLine("\nДемонстрація валідації HTML:");
+        Console.WriteLine("---------------------------");
+
+        
+        var invalidHtml = new LightElementNode("div", "block", false);
+        invalidHtml.AddChild(new LightElementNode("li", "block", false)); 
+        invalidHtml.AddChild(new LightElementNode("table", "block", false));
+        invalidHtml.AddChild(new LightElementNode("td", "inline", false)); 
+        
+        var validHtml = new LightElementNode("div", "block", false);
+        var validList = new LightElementNode("ul", "block", false);
+        validList.AddChild(new LightElementNode("li", "block", false));
+        validHtml.AddChild(validList);
+
+        var validTable = new LightElementNode("table", "block", false);
+        var validRow = new LightElementNode("tr", "block", false);
+        validRow.AddChild(new LightElementNode("th", "inline", false));
+        validTable.AddChild(validRow);
+        validHtml.AddChild(validTable);
+
+        var validator = new HtmlValidationVisitor();
+        invalidHtml.Accept(validator);
+        validator.AfterVisit();
+
+        Console.WriteLine("\nРезультати валідації (з помилками):");
+        foreach (var error in validator.Errors)
+        {
+            Console.WriteLine($"- {error}");
+        }
+
+        validator = new HtmlValidationVisitor();
+        validHtml.Accept(validator);
+        validator.AfterVisit();
+
+        Console.WriteLine("\nРезультати валідації (коректний HTML):");
+        if (validator.Errors.Count == 0)
+        {
+            Console.WriteLine("- HTML валідний, помилок не знайдено");
+        }
+        else
+        {
+            foreach (var error in validator.Errors)
+            {
+                Console.WriteLine($"- {error}");
+            }
+        }
 
     }
 }


### PR DESCRIPTION
**Added HTML validation using the Visitor pattern.**
This visitor checks element structure and context rules, such as:
- < li > must be inside < ul > or < ol >
- < tr > must be inside < table >
- < th > and <td> must be inside < tr >
- < a > must contain text
- < ul > / < ol > must have at least one < li >
- < table > is recommended to have at least one < th >
 Helps ensure semantic and well-structured HTML generation.
(This is also my 7th added feature for the Modular test №1.)
